### PR TITLE
missing JOIN results in syntax error against pg db

### DIFF
--- a/nativeCriteria-core/src/main/java/com/github/pnowy/nc/core/expressions/NativeJoin.java
+++ b/nativeCriteria-core/src/main/java/com/github/pnowy/nc/core/expressions/NativeJoin.java
@@ -50,7 +50,7 @@ public class NativeJoin
 		RIGHT_OUTER ("RIGHT OUTER JOIN"),
 		
 		/** The FUL l_ outer. */
-		FULL_OUTER ("FULL OUTER");
+		FULL_OUTER ("FULL OUTER JOIN");
 		
 		/** The type. */
 		private String type;


### PR DESCRIPTION
```NativeExps.fullJoin(...)``` results in using the enum ```NativeJoin.JoinType.FULL_OUTER```, which reads ```"FULL OUTER"``` (no JOIN). the generated SQL triggers a syntax error when executing against a postgres database (postgres 9.3), which does not support the join syntax with a missing "JOIN". 

i would expect the value of ```NativeJoin.JoinType.FULL_OUTER``` to be ```"FULL OUTER JOIN"```

quick n' ugly workaround: calling ```NativeExps.fullJoin("JOIN <mytablename>","<myalias>","<left column>","<right column>")``` ;)